### PR TITLE
improved search term handling and restructuring

### DIFF
--- a/DeepCat.js
+++ b/DeepCat.js
@@ -7,16 +7,12 @@
  */
 
 (function () {
-	var keyString = 'deepCat:';
-	var maxDepth = 10;
-	var maxResults = 50;
-	var deepCatSearchTerms;
-	var searchInput;
+	var keyString = 'deepCat:', maxDepth = 10, maxResults = 50, deepCatSearchTerms;
 	var requestUrl = '//tools.wmflabs.org/catgraph-jsonp/gptest1wiki_ns14/traverse-successors%20Category:{0}%20' + maxDepth + '%20' + maxResults;
 
 	$( function () {
 		$( '#searchform, #search' ).on( 'submit', function ( e ) {
-			searchInput = $( this ).find( '[name="search"]' ).val();
+			var searchInput = $( this ).find( '[name="search"]' ).val();
 
 			if ( matchesDeepCatKeyword( searchInput ) ) {
 				deepCatSearchTerms = getSearchTerms( searchInput );


### PR DESCRIPTION
deepCat searchterms are now replaced at the exact place. e.g.

(Berlin deepCat:Kunst) OR (Hamburg deepCat:Physik) leads to
(Berlin incategory:id:123..) OR (Hamburg incategory:id:321...)
