### PR TITLE
Defend against empty responses

### DIFF
--- a/DeepCat.js
+++ b/DeepCat.js
@@ -211,7 +211,7 @@
 		}
 
 		for ( i = 0; i < errorMessages.length; i++ ) {
-			DeepCat.ResponseErrors.addError(errorMessages);
+			DeepCat.ResponseErrors.addError(errorMessages[i]);
 		}
 
 		return newSearchTerms;

--- a/DeepCat.js
+++ b/DeepCat.js
@@ -209,6 +209,10 @@
 					DeepCat.ResponseErrors.addError(
 						createErrorMessage( 'deepcat-error-unknown-graph', null )
 					);
+				} else { // Unknown error message, shouldn't happen
+					DeepCat.ResponseErrors.addError(
+						createErrorMessage( 'deepcat-error-unexpected-response', null )
+					);
 				}
 			} else if ( categoryError[2].length === 0 ) {
 				DeepCat.ResponseErrors.addError(

--- a/DeepCat.js
+++ b/DeepCat.js
@@ -83,16 +83,35 @@
 		}
 	} );
 
-	DeepCat.ResponseErrors = {};
+	/**
+	 * ResponseErrors is a storage object that collects error messages in
+	 * methods that process the AJAX responses from CatGraph
+	 *
+	 * @type {{errors: Array}}
+	 */
+	DeepCat.ResponseErrors = {
+		errors:[]
+	};
 
+	/**
+	 * Remove all previously collected errors
+	 */
 	DeepCat.ResponseErrors.reset = function() {
 		this.errors = [];
 	};
 
+	/**
+	 * Append an error message
+	 * @param {Object} err Error message object containing mwMessage and parameters
+	 */
 	DeepCat.ResponseErrors.addError = function( err ) {
 		this.errors.push( err );
 	};
 
+	/**
+	 * Return collected errors
+	 * @returns {Array}
+	 */
 	DeepCat.ResponseErrors.getErrors = function() {
 		return this.errors ? this.errors : [];
 	};

--- a/DeepCat.js
+++ b/DeepCat.js
@@ -197,6 +197,7 @@
 			newSearchTermString = '';
 
 			if ( !responses[i]['result'] || responses[i]['result'].length == 0) {
+				// ensure we only display the message once, even when we have multiple empty results
 				errorMessages[0] = createErrorMessage( 'deepcat-error-unexpected-response', null );
 				newSearchTerms[userParameters['searchTermNum']] = '';
 			}
@@ -209,7 +210,9 @@
 			newSearchTerms[userParameters['searchTermNum']] = newSearchTermString;
 		}
 
-		DeepCat.ResponseErrors.addError(errorMessages);
+		for ( i = 0; i < errorMessages.length; i++ ) {
+			DeepCat.ResponseErrors.addError(errorMessages);
+		}
 
 		return newSearchTerms;
 	}

--- a/DeepCat.js
+++ b/DeepCat.js
@@ -113,7 +113,7 @@
 	 * @returns {Array}
 	 */
 	DeepCat.ResponseErrors.getErrors = function() {
-		return this.errors ? this.errors : [];
+		return this.errors || [];
 	};
 
 

--- a/DeepCat.js
+++ b/DeepCat.js
@@ -211,7 +211,7 @@
 		}
 
 		for ( i = 0; i < errorMessages.length; i++ ) {
-			DeepCat.ResponseErrors.addError(errorMessages[i]);
+			DeepCat.ResponseErrors.addError( errorMessages[i] );
 		}
 
 		return newSearchTerms;

--- a/DeepCat.js
+++ b/DeepCat.js
@@ -190,7 +190,7 @@
 			newSearchTerms[userParameters['searchTermNum']] = newSearchTermString;
 		}
 
-		errors.concat(errorMessages);
+		DeepCat.ResponseErrors.addError(errorMessages);
 
 		return newSearchTerms;
 	}


### PR DESCRIPTION
Catgraph should always return at least the original category id. In case
it doesn't, we check it and provide an error message.

For this change, the error variable needs to be module-global - bad style?
