### PR TITLE
Fix getSearchTerms call

### DIFF
--- a/DeepCat.js
+++ b/DeepCat.js
@@ -62,7 +62,7 @@
 			var searchInput = $( this ).find( '[name="search"]' ).val();
 
 			if ( matchesDeepCatKeyword( searchInput ) ) {
-				deepCatSearchTerms = getSearchTerms( searchInput );
+				deepCatSearchTerms = DeepCat.getSearchTerms( searchInput );
 
 				e.preventDefault();
 


### PR DESCRIPTION
getSearchTerms is in the DeepCat object for better testability. Call in
the jQuery entry faction was to the old style function.
