### PR TITLE
Do not use JSHint 2.9.0 to run checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ node_js:
 
 sudo: false
 
-install: travis_retry npm install node-qunit-phantomjs jshint jscs
+install:
+  - travis_retry npm install node-qunit-phantomjs jscs
+  - travis_retry npm install jshint@">=2.8.0 <2.9.0"
 
 script:
   - ./node_modules/jshint/bin/jshint .


### PR DESCRIPTION
As noticed in https://github.com/wmde/DeepCat-Gadget/pull/59 checks fail because evil JSHint 2.9.0 is installed. This makes (hopefully only temporarily) Travis use JSHint 2.8.0.
