### PR TITLE
Add an option not to capitalize the category names

### DIFF
--- a/DeepCat.js
+++ b/DeepCat.js
@@ -15,6 +15,7 @@
 		shouldHideHints = false,
 		shouldHideSmallHint = false,
 		interfaceUrl = '//tools.wmflabs.org/catgraph-jsonp/',
+		doNotCapitalizeSearchTerm = false,
 		mainSearchFormId;
 
 	switch( mw.config.get( 'wgUserLanguage' ) ) {
@@ -447,8 +448,12 @@
 				.replace( /"\s*$/, '' )
 				.replace( /\\(?=.)/g, '' );
 		}
+		searchTerm = searchTerm.replace( /\s+/g, '_' );
+		if( doNotCapitalizeSearchTerm ) {
+			return searchTerm;
+		}
 
-		return capitalizeFirstLetter( searchTerm.replace( /\s+/g, '_' ) );
+		return capitalizeFirstLetter( searchTerm );
 	}
 
 	function checkErrorMessage() {


### PR DESCRIPTION
A follow up to: https://github.com/wmde/DeepCat-Gadget/pull/62
Setting the new variable to `true` would allow to search for lower-case-starting categories (e.g. on wiktionary).
