### PR TITLE
Move DeepCat functions to DeepCat module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ node_js:
 sudo: false
 
 install:
-  - travis_retry npm install node-qunit-phantomjs jscs jshint
+  - travis_retry npm install node-qunit-phantomjs jscs
+  - travis_retry npm install jshint@"=2.9.2"
 
 script:
   - ./node_modules/jshint/bin/jshint .

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ node_js:
 sudo: false
 
 install:
-  - travis_retry npm install node-qunit-phantomjs jscs
-  - travis_retry npm install jshint@">=2.8.0 <2.9.0"
+  - travis_retry npm install node-qunit-phantomjs jscs jshint
 
 script:
   - ./node_modules/jshint/bin/jshint .

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ importStylesheet(  'User:USERNAME/Gadgets/DeepCat.css' );
 
 The current official release of the gadget can be found on wikipedia.org 
 ```
-mw.loader.load( "//de.wikipedia.org/w/index.php?title=User:Christoph Fischer (WMDE)/Gadgets/DeepCat.js&action=raw&ctype=text/javascript" );
-mw.loader.load( "//de.wikipedia.org/w/index.php?title=User:Christoph Fischer (WMDE)/Gadgets/DeepCat.css&action=raw&ctype=text/css" , "text/css" );
+$.when( mw.loader.using( [ 'mediawiki.api.messages', 'mediawiki.jqueryMsg' ] ), $.ready ).done( function() {
+	mw.loader.load( "//de.wikipedia.org/w/index.php?title=User:Christoph Fischer (WMDE)/gadget-test.js&action=raw&ctype=text/javascript" );
+	mw.loader.load( "//de.wikipedia.org/w/index.php?title=User:Christoph Fischer (WMDE)/gadget-test.css&action=raw&ctype=text/css" , "text/css" );
+} );
 ```
 
 ### Usage


### PR DESCRIPTION
Includes #67 
Introduce a main method.
Dependencies should now be declared when loading the gadget, see manual. 

Bug: T142838

I am not sure if this completely solves the problem of hoisting PerfektesChaos talks about in https://de.wikipedia.org/wiki/Hilfe_Diskussion:Suche/Deepcat#Richtiges_Gadget . Or if this really would mean declaring methods always before using them. ( since the approach here seems to work fine. )
