### PR TITLE
Do not use German genitive in English message

### DIFF
--- a/DeepCat.js
+++ b/DeepCat.js
@@ -45,7 +45,7 @@
 				'deepcat-missing-category': 'Please insert a category.',
 				'deepcat-hintbox-close': 'Do not show again',
 				'deepcat-smallhint-close': 'Close',
-				'deepcat-hintbox-text': 'Current limits of the DeepCat-Gadgets per search word:<br/>' +
+				'deepcat-hintbox-text': 'Current limits of the DeepCat gadget per search word:<br/>' +
 				'Max. search depth: ' + maxDepth + ' / Max. result categories: ' + maxResults + '<br/>' +
 				'<a style="float:left" href="//wikitech.wikimedia.org/wiki/Nova_Resource:Catgraph/Deepcat"  target="_blank">Additional information</a>',
 				'deepcat-hintbox-small': 'Max. category-depth: ' + maxDepth + '<br/>Max. categories: ' + maxResults


### PR DESCRIPTION
Also changes punctuation in gadget's name.

I would also re-consider the term "search word" but let's not do it here
