### PR TITLE
load DeepCat only once

### DIFF
--- a/DeepCat.js
+++ b/DeepCat.js
@@ -642,9 +642,20 @@
 		}
 	}
 
-	$( function() {
-		deepCatMain();
-	} );
+	if( mw.loader.getState( 'ext.gadget.DeepCat' )  !==  'ready' ) {
+		mw.loader.state( 'ext.gadget.DeepCat', 'ready' );
+		mw.loader.using(
+			[
+				'mediawiki.api.messages',
+				'mediawiki.cookie',
+				'mediawiki.util',
+				'mediawiki.jqueryMsg'
+			],
+			function() {
+				$( deepCatMain );
+			}
+		);
+	}
 
 	mw.libs.deepCat = DeepCat;
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,8 @@ importStylesheet(  'User:USERNAME/Gadgets/DeepCat.css' );
 
 The current official release of the gadget can be found on wikipedia.org 
 ```
-$.when( mw.loader.using( [ 'mediawiki.api.messages', 'mediawiki.jqueryMsg' ] ), $.ready ).done( function() {
-    mw.loader.load( "//de.wikipedia.org/w/index.php?title=User:Christoph Fischer (WMDE)/Gadgets/DeepCat.js&action=raw&ctype=text/javascript" );
-    mw.loader.load( "//de.wikipedia.org/w/index.php?title=User:Christoph Fischer (WMDE)/Gadgets/DeepCat.css&action=raw&ctype=text/css" , "text/css" );
-} );
+mw.loader.load( "//de.wikipedia.org/w/index.php?title=User:Christoph Fischer (WMDE)/Gadgets/DeepCat.js&action=raw&ctype=text/javascript" );
+mw.loader.load( "//de.wikipedia.org/w/index.php?title=User:Christoph Fischer (WMDE)/Gadgets/DeepCat.css&action=raw&ctype=text/css" , "text/css" );
 ```
 
 ### Usage

--- a/tests/mediaWiki.mock.js
+++ b/tests/mediaWiki.mock.js
@@ -40,5 +40,10 @@ mediaWiki = {
 		getParamValue: function() {
 			return '';
 		}
+	},
+	loader: {
+		getState: function() {
+			return 'ready';
+		}
 	}
 };


### PR DESCRIPTION
Checks all dependencies before running main method.
Mock the loader so QUnit tests wont run the main method and check for dependencies.

Bug: T144166
