### PR TITLE
use newest jshint version again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: false
 
 install:
   - travis_retry npm install node-qunit-phantomjs jscs
-  - travis_retry npm install jshint@"=2.9.2"
+  - travis_retry npm install jshint
 
 script:
   - ./node_modules/jshint/bin/jshint .


### PR DESCRIPTION
The bug with -W100 was fixed in 2.9.4. See
https://github.com/jshint/jshint/issues/3013#issuecomment-255233870
