### PR TITLE
Allow user to specify search-depth

### DIFF
--- a/DeepCat.js
+++ b/DeepCat.js
@@ -9,6 +9,7 @@
 	var DeepCat = {},
 		keyString = 'deepcat:',
 		defaultDepth = 15,
+		maxDepth = 20,
 		maxResults = 70,
 		ajaxTimeout = 10000,
 		interfaceUrl = '//tools.wmflabs.org/catgraph-jsonp/',
@@ -428,7 +429,7 @@
 		if( /~[0-9]+$/.test ( searchTerm ) ) {
 			var split      = searchTerm.split("~");
 			searchTerm = split[0];
-			depth      = split[split.length - 1];
+			depth      = Math.min(split[split.length - 1], maxDepth);
 		}
 
 		return {

--- a/DeepCat.js
+++ b/DeepCat.js
@@ -414,9 +414,10 @@
 
 	/**
 	 * @param {string} searchTerm
-	 * @return {string}
+	 * @return {depth: {string}, searchTerm: {string}}
 	 */
 	DeepCat.extractDeepCatCategory = function( searchTerm ) {
+		let depth = defaultDepth;
 		searchTerm = searchTerm.replace( new RegExp( '\\s*-?\\b' + keyString + '\\s*', 'i' ), '' );
 
 		if( /^\s*"/.test( searchTerm ) ) {
@@ -425,11 +426,9 @@
 				.replace( /\\(?=.)/g, '' );
 		}
 		if( /~[0-9]+$/.test ( searchTerm ) ) {
-			depth      = searchTerm.split("~")[1];
-			searchTerm = searchTerm.split("~")[0];
-		}
-		else {
-			depth = defaultDepth;
+			var split      = searchTerm.split("~");
+			searchTerm = split[0];
+			depth      = split[split.length - 1];
 		}
 
 		return {

--- a/DeepCat.js
+++ b/DeepCat.js
@@ -35,9 +35,9 @@
 				'deepcat-hintbox-close': 'Zuk&uuml;nftig ausblenden',
 				'deepcat-smallhint-close': 'Ausblenden',
 				'deepcat-hintbox-text': 'Momentane Einschränkung des DeepCat-Gadgets pro Suchbegriff:<br/>' +
-				'Standard Kategoriensuchtiefe: ' + defaultDepth + ' / Max. Kategorienanzahl: ' + maxResults + '<br/>' +
+				'Max. Kategoriensuchtiefe: ' + maxDepth + ' / Max. Kategorienanzahl: ' + maxResults + '<br/>' +
 				'<a style="float:left" href="//de.wikipedia.org/wiki/Hilfe:Suche/Deepcat" target="_blank">Weitere Informationen</a>',
-				'deepcat-hintbox-small': 'Standard Kategoriensuchtiefe: ' + defaultDepth + '<br/>Max. Kategorienanzahl: ' + maxResults
+'deepcat-hintbox-small': 'Max. Kategoriensuchtiefe: ' + maxDepth + '<br/>Max. Kategorienanzahl: ' + maxResults
 			} );
 			break;
 		default:
@@ -50,9 +50,9 @@
 				'deepcat-hintbox-close': 'Do not show again',
 				'deepcat-smallhint-close': 'Close',
 				'deepcat-hintbox-text': 'Current limits of the DeepCat gadget per search word:<br/>' +
-				'Default search depth: ' + defaultDepth + ' / Max. result categories: ' + maxResults + '<br/>' +
+				'Max. search depth: ' + maxDepth + ' / Max. result categories: ' + maxResults + '<br/>' +
 				'<a style="float:left" href="//wikitech.wikimedia.org/wiki/Nova_Resource:Catgraph/Deepcat"  target="_blank">Additional information</a>',
-				'deepcat-hintbox-small': 'Default category-depth: ' + defaultDepth + '<br/>Max. categories: ' + maxResults
+'deepcat-hintbox-small': 'Max. category-depth: ' + maxDepth + '<br/>Max. categories: ' + maxResults
 			} );
 			break;
 	}
@@ -140,7 +140,8 @@
 	}
 
 	function getAjaxRequest( searchTerm, searchTermNum ) {
-		({  categoryString, depth } = DeepCat.extractDeepCatCategory( searchTerm ));
+		categoryString = DeepCat.extractDeepCatCategory( searchTerm );
+		depth = DeepCat.extractDeepCatCategoryDepth( searchTerm );
 		var	userParameter = {
 				negativeSearch: searchTerm.charAt( 0 ) === '-',
 				searchTermNum: searchTermNum
@@ -415,10 +416,9 @@
 
 	/**
 	 * @param {string} searchTerm
-	 * @return {depth: {string}, searchTerm: {string}}
+	 * @return {string}
 	 */
 	DeepCat.extractDeepCatCategory = function( searchTerm ) {
-		let depth = defaultDepth;
 		searchTerm = searchTerm.replace( new RegExp( '\\s*-?\\b' + keyString + '\\s*', 'i' ), '' );
 
 		if( /^\s*"/.test( searchTerm ) ) {
@@ -429,13 +429,25 @@
 		if( /~[0-9]+$/.test ( searchTerm ) ) {
 			var split      = searchTerm.split("~");
 			searchTerm = split[0];
+		}
+
+		return removeUnicodeNonPrintables( replaceWhiteSpace( searchTerm ) );
+	};
+
+	/**
+	 * @param {string} searchTerm
+	 * @return {string}
+	 */
+	DeepCat.extractDeepCatCategoryDepth = function( searchTerm ) {
+		let depth = defaultDepth;
+		searchTerm = searchTerm.trim();
+
+		if( /~[0-9]+$/.test ( searchTerm ) ) {
+			var split      = searchTerm.split("~");
 			depth      = Math.min(split[split.length - 1], maxDepth);
 		}
 
-		return {
-			categoryString: removeUnicodeNonPrintables( replaceWhiteSpace( searchTerm ) ),
-			depth: depth
-		};
+		return depth;
 	};
 
 	/**

--- a/DeepCat.js
+++ b/DeepCat.js
@@ -424,7 +424,7 @@
 				.replace( /"\s*$/, '' )
 				.replace( /\\(?=.)/g, '' );
 		}
-		if( /~[0-9]*$/.test ( searchTerm ) ) {
+		if( /~[0-9]+$/.test ( searchTerm ) ) {
 			depth      = searchTerm.split("~")[1];
 			searchTerm = searchTerm.split("~")[0];
 		}

--- a/tests/DeepCat.tests.js
+++ b/tests/DeepCat.tests.js
@@ -123,66 +123,96 @@
 
 	QUnit.test( 'extractDeepCatCategory', function( assert ) {
 		assert.deepEqual(
-			deepCat.extractDeepCatCategory( 'deepcat:Physik' ),
+			deepCat.extractDeepCatCategory( 'deepcat:Physik' ).categoryString,
 			'Physik',
 			'extractDeepCatCategory: the keyword should be removed from the DeepCat-term'
 		);
 		assert.deepEqual(
-			deepCat.extractDeepCatCategory( '  deepcat:   Physik' ),
+			deepCat.extractDeepCatCategory( '  deepcat:   Physik' ).categoryString,
 			'Physik',
 			'extractDeepCatCategory: whitspaces around the keyword should be removed from the DeepCat-term'
 		);
 		assert.deepEqual(
-			deepCat.extractDeepCatCategory( 'deepcat:"Geschichte_der_Physik"' ),
+			deepCat.extractDeepCatCategory( 'deepcat:"Geschichte_der_Physik"' ).categoryString,
 			'Geschichte_der_Physik',
 			'extractDeepCatCategory: double-quotes should be removed from the DeepCat-term'
 		);
 		assert.deepEqual(
-			deepCat.extractDeepCatCategory( 'deepcat:"Geschichte der Physik"' ),
+			deepCat.extractDeepCatCategory( 'deepcat:"Geschichte der Physik"' ).categoryString,
 			'Geschichte_der_Physik',
 			'extractDeepCatCategory: spaces should be replaced with underscore in the DeepCat-term'
 		);
 		assert.deepEqual(
-			deepCat.extractDeepCatCategory( 'deepcat:"Geschichte　der　Physik"' ),
+			deepCat.extractDeepCatCategory( 'deepcat:"Geschichte　der　Physik"' ).categoryString,
 			'Geschichte_der_Physik',
 			'extractDeepCatCategory: ideographic spaces should be replaced with underscore in the DeepCat-term'
 		);
 		assert.deepEqual(
-			deepCat.extractDeepCatCategory( 'deepcat:"Geschichte　 _ _der　Physik"' ),
+			deepCat.extractDeepCatCategory( 'deepcat:"Geschichte　 _ _der　Physik"' ).categoryString,
 			'Geschichte_der_Physik',
 			'extractDeepCatCategory: mixed spaces/underscores should be replaced with one underscore in the DeepCat-term'
 		);
 		/* jshint -W100 */
 		assert.deepEqual(
-			deepCat.extractDeepCatCategory( 'deepcat:"Classical mechanics stubs‎"' ),
+			deepCat.extractDeepCatCategory( 'deepcat:"Classical mechanics stubs‎"' ).categoryString,
 			'Classical_mechanics_stubs',
 			'extractDeepCatCategory: LTR-mark character should be removed from DeepCat-term'
 		);
 		/* jshint +W100 */
 		assert.deepEqual(
-			deepCat.extractDeepCatCategory( 'deepcat:"Waters\'_Edge_Park"' ),
+			deepCat.extractDeepCatCategory( 'deepcat:"Waters\'_Edge_Park"' ).categoryString,
 			'Waters\'_Edge_Park',
 			'extractDeepCatCategory: single quotes should stay the same in the DeepCat-term'
 		);
 		assert.deepEqual(
-			deepCat.extractDeepCatCategory( 'deepcat:"Springende Bälle"' ),
+			deepCat.extractDeepCatCategory( 'deepcat:"Springende Bälle"' ).categoryString,
 			'Springende_Bälle',
 			'extractDeepCatCategory: umlauts should stay the same in the DeepCat-term'
 		);
 		assert.deepEqual(
-			deepCat.extractDeepCatCategory( 'deepcat:貓' ),
+			deepCat.extractDeepCatCategory( 'deepcat:貓' ).categoryString,
 			'貓',
 			'extractDeepCatCategory: chinese characters should stay the same in the DeepCat-term'
 		);
 		assert.deepEqual(
-			deepCat.extractDeepCatCategory( 'deepcat:Кошки' ),
+			deepCat.extractDeepCatCategory( 'deepcat:Кошки' ).categoryString,
 			'Кошки',
 			'extractDeepCatCategory: cyrillic characters should stay the same in the DeepCat-term'
 		);
 		assert.deepEqual(
-			deepCat.extractDeepCatCategory( 'deepcat:قطط' ),
+			deepCat.extractDeepCatCategory( 'deepcat:قطط' ).categoryString,
 			'قطط',
 			'extractDeepCatCategory: arabic characters should stay the same in the DeepCat-term'
+		);
+		assert.deepEqual(
+			deepCat.extractDeepCatCategory( 'deepcat:Physik' ).depth,
+			'15',
+			'extractDeepCatCategory: defaut depth should be 15'
+		);
+		assert.deepEqual(
+			deepCat.extractDeepCatCategory( 'deepcat:Physik~21' ).depth,
+			'21',
+			'extractDeepCatCategory: number after ~ should be parsed as depth'
+		);
+		assert.deepEqual(
+			deepCat.extractDeepCatCategory( 'deepcat:Physik~foo' ).categoryString,
+			'Physik~foo',
+			'extractDeepCatCategory: text after ~ should not be parsed as depth'
+		);
+		assert.deepEqual(
+			deepCat.extractDeepCatCategory( 'deepcat:Physik~foo' ).depth,
+			'15',
+			'extractDeepCatCategory: text after ~ should not be parsed as depth'
+		);
+		assert.deepEqual(
+			deepCat.extractDeepCatCategory( 'deepcat:Physik~14~21' ).depth,
+			'21',
+			'extractDeepCatCategory: number after last ~ should be parsed as depth'
+		);
+		assert.deepEqual(
+			deepCat.extractDeepCatCategory( 'deepcat:Physik~14~21' ).categoryString,
+			'Physik~14',
+			'extractDeepCatCategory: every before last ~ should be parsed as Category-Name'
 		);
 	} );
 


### PR DESCRIPTION
It was wished/remarked several times, that the user should be able to choose how deep the search should go down the category-tree.

The demand seems to be less to search even deeper, but to limit the depth to the exact value, wich is appropriate for the search problem considerd.

This patch allows the user to specify the search-depth by the syntax
`    deepcat:categoryname~depth
`
where `depth` is an positive interger.